### PR TITLE
fix text on path, refactor

### DIFF
--- a/a3_translit/scripts/A3 Translit (ID).jsx
+++ b/a3_translit/scripts/A3 Translit (ID).jsx
@@ -11,37 +11,9 @@ app.doScript(Main, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT
 function Main() {
 
   var changeObject;
+  var selList = app.selection;
 
-  if (app.selection.length < 1) { exit(); }
-
-  for (var i = 0; i < app.selection.length; i++) {
-
-    switch (app.selection[i].constructor) {
-      case TextFrame:
-      case TextColumn:
-      case Text:
-      case Cell:
-      case Paragraph:
-      case Word:
-        changeObject = app.selection[i];
-        break;
-      case GraphicLine:
-      case Oval:
-      case Polygon:
-      case Rectangle:
-      case TextFrame:
-      case EPSText:
-      case SplineItem:
-        if (app.selection[i].textPaths.length > 0) {
-          changeObject = app.selection[i].textPaths[0];
-        }
-        break;
-      default:
-        break;
-    }
-
-    translit();
-  }
+  if (selList.length < 1) { exit(); }
 
   function myGrep(findString, changeString) {
     app.findGrepPreferences = NothingEnum.NOTHING;
@@ -50,9 +22,7 @@ function Main() {
       app.findGrepPreferences.findWhat = findString;
       app.changeGrepPreferences.changeTo = changeString;
       changeObject.changeGrep();
-    } catch (e) {
-      alert(e + ' at line ' + e.line);
-    }
+    } catch (e) {}
   }
 
   function translit() {
@@ -141,5 +111,44 @@ function Main() {
     myGrep('Я', 'Ia');
     myGrep("'", "");
     myGrep("’", "");
+  }
+
+  function switchAndTranslit(chObj) {
+    switch (chObj.constructor) {
+      case TextColumn:
+      case TextFrame:
+      case Text:
+      case Cell:
+      case Paragraph:
+      case Word:
+        changeObject = chObj;
+        break;
+      case GraphicLine:
+      case Oval:
+      case Polygon:
+      case Rectangle:
+      case EPSText:
+      case SplineItem:
+        if (chObj.textPaths.length > 0) {
+          changeObject = chObj.textPaths[0];
+        }
+        break;
+      default:
+        break;
+    }
+
+    translit();
+  }
+
+  for (var i = selList.length; i--;) {
+    if (selList[i] instanceof Group) {
+      for (var j = selList[i].allPageItems.length; j--;) {
+        changeObject = selList[i].allPageItems[j];
+        switchAndTranslit(changeObject);
+      }
+    } else {
+      changeObject = selList[i];
+      switchAndTranslit(changeObject);
+    }
   }
 }

--- a/a3_translit/scripts/A3 Translit (ID).jsx
+++ b/a3_translit/scripts/A3 Translit (ID).jsx
@@ -1,1 +1,137 @@
-// v.0.1// Транслітератор тексту від Агентів змін — http://translit.a3.kyiv.ua. Автор — Олександр Колодько.// Інструмент для транслітерації топонімів. У основі географічна транслітерація УКППТ 1996, у якій прибрані апострофи, усунено дублювання у «iie» та «iia», «ьо» транслітерується як «io».// Побажання та відгуки надсилайте на info@a3.kyiv.ua// https://github.com/agentyzmin/a3-tools/tree/master/a3_translitif ( app.selection.length < 1 ){ exit(); }for( var i = 0; i < app.selection.length; i++ ){  if    ( app.selection[i] instanceof TextFrame ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof Text ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof TextColumn ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof TextFrame ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof Cell ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof Paragraph ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else if     ( app.selection[i] instanceof Word ){      var translitText = translit(app.selection[i].contents);      app.selection[i].contents = translitText;    }  else { exit(); }}function translit(input) {    input = input || '';    return input        .replace(/іє/g, 'ie') // Exception        .replace(/Іє/g, 'Ie') // Exception        .replace(/ія/g, 'ia') // Exception        .replace(/Ія/g, 'Ia') // Exception        .replace(/зг/g, 'zgh') // Exception        .replace(/Зг/g, 'Zgh') // Exception        .replace(/ьо/g, 'io') // Exception        .replace(/а/g, 'a')        .replace(/б/g, 'b')        .replace(/в/g, 'v')        .replace(/г/g, 'h')        .replace(/ґ/g, 'g')        .replace(/д/g, 'd')        .replace(/е/g, 'e')        .replace(/(^|\s)є/g, '$1ye')        .replace(/є/g, 'ie')        .replace(/ж/g, 'zh')        .replace(/з/g, 'z')        .replace(/и/g, 'y')        .replace(/і/g, 'i')        .replace(/(^|\s)ї/g, '$1yi')        .replace(/ї/g, 'i')        .replace(/(^|\s)й/g, '$1y')        .replace(/й/g, 'i')        .replace(/к/g, 'k')        .replace(/л/g, 'l')        .replace(/м/g, 'm')        .replace(/н/g, 'n')        .replace(/о/g, 'o')        .replace(/п/g, 'p')        .replace(/р/g, 'r')        .replace(/с/g, 's')        .replace(/т/g, 't')        .replace(/у/g, 'u')        .replace(/ф/g, 'f')        .replace(/х/g, 'kh')        .replace(/ц/g, 'ts')        .replace(/ч/g, 'ch')        .replace(/ш/g, 'sh')        .replace(/щ/g, 'sch')        .replace(/ь/g, '')        .replace(/(^|\s)ю/g, '$1yu')        .replace(/ю/g, 'iu')        .replace(/(^|\s)я/g, '$1ya')        .replace(/я/g, 'ia')        .replace(/А/g, 'A')        .replace(/Б/g, 'B')        .replace(/В/g, 'V')        .replace(/Г/g, 'H')        .replace(/Ґ/g, 'G')        .replace(/Д/g, 'D')        .replace(/Е/g, 'E')        .replace(/(^|\s)Є/g, '$1Ye')        .replace(/Є/g, 'Ie')        .replace(/Ж/g, 'Zh')        .replace(/З/g, 'Z')        .replace(/И/g, 'Y')        .replace(/І/g, 'I')        .replace(/(^|\s)Ї/g, '$1Yi')        .replace(/Ї/g, 'I')        .replace(/(^|\s)Й/g, '$1Y')        .replace(/Й/g, 'I')        .replace(/К/g, 'K')        .replace(/Л/g, 'L')        .replace(/М/g, 'M')        .replace(/Н/g, 'N')        .replace(/О/g, 'O')        .replace(/П/g, 'P')        .replace(/Р/g, 'R')        .replace(/С/g, 'S')        .replace(/Т/g, 'T')        .replace(/У/g, 'U')        .replace(/Ф/g, 'F')        .replace(/Х/g, 'Kh')        .replace(/Ц/g, 'Ts')        .replace(/Ч/g, 'Ch')        .replace(/Ш/g, 'Sh')        .replace(/Щ/g, 'Sch')        .replace(/Ь/g, '')        .replace(/(^|\s)Ю/g, '$1Yu')        .replace(/Ю/g, 'Iu')        .replace(/(^|\s)Я/g, '$1Ya')        .replace(/Я/g, 'Ia')        .replace(/'/g, '')        .replace(/’/g, '');}//redraw();
+// v.0.1
+// Транслітератор тексту від Агентів змін — http://translit.a3.kyiv.ua. Автор — Олександр Колодько.
+// Інструмент для транслітерації топонімів. У основі географічна транслітерація УКППТ 1996, у якій прибрані апострофи, усунено дублювання у «iie» та «iia», «ьо» транслітерується як «io».
+// Побажання та відгуки надсилайте на info@a3.kyiv.ua
+// https://github.com/agentyzmin/a3-tools/tree/master/a3_translit
+
+// Line below allows for script to be undone entirely. Comment it and uncomment the next line "Main()" to be able to undo the script step by step
+app.doScript(Main, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, "Run Script");
+// Main();
+
+function Main() {
+
+  if (app.selection.length < 1) { exit(); }
+
+  for (var i = 0; i < app.selection.length; i++) {
+
+    switch (app.selection[i].constructor) {
+      case TextFrame:
+      case TextColumn:
+      case Text:
+      case Cell:
+      case Paragraph:
+      case Word:
+        var translitText = translit(app.selection[i].contents);
+        app.selection[i].contents = translitText;
+        break;
+      case GraphicLine:
+      case Oval:
+      case Polygon:
+      case Rectangle:
+      case TextFrame:
+      case EPSText:
+      case SplineItem:
+        if (app.selection[i].textPaths.length > 0) {
+          var translitText = translit(app.selection[i].textPaths[0].contents);
+          app.selection[i].textPaths[0].contents = translitText;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  
+  function translit(input) {
+    input = input || '';
+
+    return input
+      .replace(/іє/g, 'ie') // Exception
+      .replace(/Іє/g, 'Ie') // Exception
+      .replace(/ія/g, 'ia') // Exception
+      .replace(/Ія/g, 'Ia') // Exception
+      .replace(/зг/g, 'zgh') // Exception
+      .replace(/Зг/g, 'Zgh') // Exception
+      .replace(/ьо/g, 'io') // Exception
+      .replace(/а/g, 'a')
+      .replace(/б/g, 'b')
+      .replace(/в/g, 'v')
+      .replace(/г/g, 'h')
+      .replace(/ґ/g, 'g')
+      .replace(/д/g, 'd')
+      .replace(/е/g, 'e')
+      .replace(/(^|\s)є/g, '$1ye')
+      .replace(/є/g, 'ie')
+      .replace(/ж/g, 'zh')
+      .replace(/з/g, 'z')
+      .replace(/и/g, 'y')
+      .replace(/і/g, 'i')
+      .replace(/(^|\s)ї/g, '$1yi')
+      .replace(/ї/g, 'i')
+      .replace(/(^|\s)й/g, '$1y')
+      .replace(/й/g, 'i')
+      .replace(/к/g, 'k')
+      .replace(/л/g, 'l')
+      .replace(/м/g, 'm')
+      .replace(/н/g, 'n')
+      .replace(/о/g, 'o')
+      .replace(/п/g, 'p')
+      .replace(/р/g, 'r')
+      .replace(/с/g, 's')
+      .replace(/т/g, 't')
+      .replace(/у/g, 'u')
+      .replace(/ф/g, 'f')
+      .replace(/х/g, 'kh')
+      .replace(/ц/g, 'ts')
+      .replace(/ч/g, 'ch')
+      .replace(/ш/g, 'sh')
+      .replace(/щ/g, 'sch')
+      .replace(/ь/g, '')
+      .replace(/(^|\s)ю/g, '$1yu')
+      .replace(/ю/g, 'iu')
+      .replace(/(^|\s)я/g, '$1ya')
+      .replace(/я/g, 'ia')
+      .replace(/А/g, 'A')
+      .replace(/Б/g, 'B')
+      .replace(/В/g, 'V')
+      .replace(/Г/g, 'H')
+      .replace(/Ґ/g, 'G')
+      .replace(/Д/g, 'D')
+      .replace(/Е/g, 'E')
+      .replace(/(^|\s)Є/g, '$1Ye')
+      .replace(/Є/g, 'Ie')
+      .replace(/Ж/g, 'Zh')
+      .replace(/З/g, 'Z')
+      .replace(/И/g, 'Y')
+      .replace(/І/g, 'I')
+      .replace(/(^|\s)Ї/g, '$1Yi')
+      .replace(/Ї/g, 'I')
+      .replace(/(^|\s)Й/g, '$1Y')
+      .replace(/Й/g, 'I')
+      .replace(/К/g, 'K')
+      .replace(/Л/g, 'L')
+      .replace(/М/g, 'M')
+      .replace(/Н/g, 'N')
+      .replace(/О/g, 'O')
+      .replace(/П/g, 'P')
+      .replace(/Р/g, 'R')
+      .replace(/С/g, 'S')
+      .replace(/Т/g, 'T')
+      .replace(/У/g, 'U')
+      .replace(/Ф/g, 'F')
+      .replace(/Х/g, 'Kh')
+      .replace(/Ц/g, 'Ts')
+      .replace(/Ч/g, 'Ch')
+      .replace(/Ш/g, 'Sh')
+      .replace(/Щ/g, 'Sch')
+      .replace(/Ь/g, '')
+      .replace(/(^|\s)Ю/g, '$1Yu')
+      .replace(/Ю/g, 'Iu')
+      .replace(/(^|\s)Я/g, '$1Ya')
+      .replace(/Я/g, 'Ia')
+      .replace(/'/g, '')
+      .replace(/’/g, '');
+  }
+
+}
+
+//redraw();

--- a/a3_translit/scripts/A3 Translit (ID).jsx
+++ b/a3_translit/scripts/A3 Translit (ID).jsx
@@ -4,11 +4,13 @@
 // Побажання та відгуки надсилайте на info@a3.kyiv.ua
 // https://github.com/agentyzmin/a3-tools/tree/master/a3_translit
 
-// Line below allows for script to be undone entirely. Comment it and uncomment the next line "Main()" to be able to undo the script step by step
+// Line below allows for script to be undone at once. Comment it and uncomment the next line "Main()" to be able to undo the script step by step
 app.doScript(Main, ScriptLanguage.JAVASCRIPT, undefined, UndoModes.ENTIRE_SCRIPT, "Run Script");
 // Main();
 
 function Main() {
+
+  var changeObject;
 
   if (app.selection.length < 1) { exit(); }
 
@@ -21,8 +23,7 @@ function Main() {
       case Cell:
       case Paragraph:
       case Word:
-        var translitText = translit(app.selection[i].contents);
-        app.selection[i].contents = translitText;
+        changeObject = app.selection[i];
         break;
       case GraphicLine:
       case Oval:
@@ -32,106 +33,113 @@ function Main() {
       case EPSText:
       case SplineItem:
         if (app.selection[i].textPaths.length > 0) {
-          var translitText = translit(app.selection[i].textPaths[0].contents);
-          app.selection[i].textPaths[0].contents = translitText;
+          changeObject = app.selection[i].textPaths[0];
         }
         break;
       default:
         break;
     }
-  }
-  
-  function translit(input) {
-    input = input || '';
 
-    return input
-      .replace(/іє/g, 'ie') // Exception
-      .replace(/Іє/g, 'Ie') // Exception
-      .replace(/ія/g, 'ia') // Exception
-      .replace(/Ія/g, 'Ia') // Exception
-      .replace(/зг/g, 'zgh') // Exception
-      .replace(/Зг/g, 'Zgh') // Exception
-      .replace(/ьо/g, 'io') // Exception
-      .replace(/а/g, 'a')
-      .replace(/б/g, 'b')
-      .replace(/в/g, 'v')
-      .replace(/г/g, 'h')
-      .replace(/ґ/g, 'g')
-      .replace(/д/g, 'd')
-      .replace(/е/g, 'e')
-      .replace(/(^|\s)є/g, '$1ye')
-      .replace(/є/g, 'ie')
-      .replace(/ж/g, 'zh')
-      .replace(/з/g, 'z')
-      .replace(/и/g, 'y')
-      .replace(/і/g, 'i')
-      .replace(/(^|\s)ї/g, '$1yi')
-      .replace(/ї/g, 'i')
-      .replace(/(^|\s)й/g, '$1y')
-      .replace(/й/g, 'i')
-      .replace(/к/g, 'k')
-      .replace(/л/g, 'l')
-      .replace(/м/g, 'm')
-      .replace(/н/g, 'n')
-      .replace(/о/g, 'o')
-      .replace(/п/g, 'p')
-      .replace(/р/g, 'r')
-      .replace(/с/g, 's')
-      .replace(/т/g, 't')
-      .replace(/у/g, 'u')
-      .replace(/ф/g, 'f')
-      .replace(/х/g, 'kh')
-      .replace(/ц/g, 'ts')
-      .replace(/ч/g, 'ch')
-      .replace(/ш/g, 'sh')
-      .replace(/щ/g, 'sch')
-      .replace(/ь/g, '')
-      .replace(/(^|\s)ю/g, '$1yu')
-      .replace(/ю/g, 'iu')
-      .replace(/(^|\s)я/g, '$1ya')
-      .replace(/я/g, 'ia')
-      .replace(/А/g, 'A')
-      .replace(/Б/g, 'B')
-      .replace(/В/g, 'V')
-      .replace(/Г/g, 'H')
-      .replace(/Ґ/g, 'G')
-      .replace(/Д/g, 'D')
-      .replace(/Е/g, 'E')
-      .replace(/(^|\s)Є/g, '$1Ye')
-      .replace(/Є/g, 'Ie')
-      .replace(/Ж/g, 'Zh')
-      .replace(/З/g, 'Z')
-      .replace(/И/g, 'Y')
-      .replace(/І/g, 'I')
-      .replace(/(^|\s)Ї/g, '$1Yi')
-      .replace(/Ї/g, 'I')
-      .replace(/(^|\s)Й/g, '$1Y')
-      .replace(/Й/g, 'I')
-      .replace(/К/g, 'K')
-      .replace(/Л/g, 'L')
-      .replace(/М/g, 'M')
-      .replace(/Н/g, 'N')
-      .replace(/О/g, 'O')
-      .replace(/П/g, 'P')
-      .replace(/Р/g, 'R')
-      .replace(/С/g, 'S')
-      .replace(/Т/g, 'T')
-      .replace(/У/g, 'U')
-      .replace(/Ф/g, 'F')
-      .replace(/Х/g, 'Kh')
-      .replace(/Ц/g, 'Ts')
-      .replace(/Ч/g, 'Ch')
-      .replace(/Ш/g, 'Sh')
-      .replace(/Щ/g, 'Sch')
-      .replace(/Ь/g, '')
-      .replace(/(^|\s)Ю/g, '$1Yu')
-      .replace(/Ю/g, 'Iu')
-      .replace(/(^|\s)Я/g, '$1Ya')
-      .replace(/Я/g, 'Ia')
-      .replace(/'/g, '')
-      .replace(/’/g, '');
+    translit();
   }
 
+  function myGrep(findString, changeString) {
+    app.findGrepPreferences = NothingEnum.NOTHING;
+    app.changeGrepPreferences = NothingEnum.NOTHING;
+    try {
+      app.findGrepPreferences.findWhat = findString;
+      app.changeGrepPreferences.changeTo = changeString;
+      changeObject.changeGrep();
+    } catch (e) {
+      alert(e + ' at line ' + e.line);
+    }
+  }
+
+  function translit() {
+    myGrep('іє', 'ie'); // Exception
+    myGrep('Іє', 'Ie'); // Exception
+    myGrep('ія', 'ia'); // Exception
+    myGrep('Ія', 'Ia'); // Exception
+    myGrep('зг', 'zgh');// Exception
+    myGrep('Зг', 'Zgh'); // Exception
+    myGrep('ьо', 'io'); // Exception
+    myGrep('а', 'a');
+    myGrep('б', 'b');
+    myGrep('в', 'v');
+    myGrep('г', 'h');
+    myGrep('ґ', 'g');
+    myGrep('д', 'd');
+    myGrep('е', 'e');
+    myGrep('(^|\\s)є', '$1ye');
+    myGrep('є', 'ie');
+    myGrep('ж', 'zh');
+    myGrep('з', 'z');
+    myGrep('и', 'y');
+    myGrep('і', 'i');
+    myGrep('(^|\\s)ї', '$1yi');
+    myGrep('ї', 'i');
+    myGrep('(^|\\s)й', '$1y');
+    myGrep('й', 'i');
+    myGrep('к', 'k');
+    myGrep('л', 'l');
+    myGrep('м', 'm');
+    myGrep('н', 'n');
+    myGrep('о', 'o');
+    myGrep('п', 'p');
+    myGrep('р', 'r');
+    myGrep('с', 's');
+    myGrep('т', 't');
+    myGrep('у', 'u');
+    myGrep('ф', 'f');
+    myGrep('х', 'kh');
+    myGrep('ц', 'ts');
+    myGrep('ч', 'ch');
+    myGrep('ш', 'sh');
+    myGrep('щ', 'sch');
+    myGrep('ь', '');
+    myGrep('(^|\\s)ю', '$1yu');
+    myGrep('ю', 'iu');
+    myGrep('(^|\\s)я', '$1ya');
+    myGrep('я', 'ia');
+    myGrep('А', 'A');
+    myGrep('Б', 'B');
+    myGrep('В', 'V');
+    myGrep('Г', 'H');
+    myGrep('Ґ', 'G');
+    myGrep('Д', 'D');
+    myGrep('Е', 'E');
+    myGrep('(^|\\s)Є', '$1Ye');
+    myGrep('Є', 'Ie');
+    myGrep('Ж', 'Zh');
+    myGrep('З', 'Z');
+    myGrep('И', 'Y');
+    myGrep('І', 'I');
+    myGrep('(^|\\s)Ї', '$1Yi');
+    myGrep('Ї', 'I');
+    myGrep('(^|\\s)Й', '$1Y');
+    myGrep('Й', 'I');
+    myGrep('К', 'K');
+    myGrep('Л', 'L');
+    myGrep('М', 'M');
+    myGrep('Н', 'N');
+    myGrep('О', 'O');
+    myGrep('П', 'P');
+    myGrep('Р', 'R');
+    myGrep('С', 'S');
+    myGrep('Т', 'T');
+    myGrep('У', 'U');
+    myGrep('Ф', 'F');
+    myGrep('Х', 'Kh');
+    myGrep('Ц', 'Ts');
+    myGrep('Ч', 'Ch');
+    myGrep('Ш', 'Sh');
+    myGrep('Щ', 'Sch');
+    myGrep('Ь', '');
+    myGrep('(^|\\s)Ю', '$1Yu');
+    myGrep('Ю', 'Iu');
+    myGrep('(^|\\s)Я', '$1Ya');
+    myGrep('Я', 'Ia');
+    myGrep("'", "");
+    myGrep("’", "");
+  }
 }
-
-//redraw();


### PR DESCRIPTION
Привет,

Вроде получилось побороть текст на кривой. Когда выделяется потенциальный родитель `textPath`, например `Polygon` или `Oval`, надо копнуть глубже и посмотреть есть ли в нем этот `textPath`, и работать уже с `app.selection[i].textPaths[0].contents`.

Заменил весь блок `else if` на более компактный `switch`.
Добавил `app.doScript`, чтобы весь скрипт отменялся одной кнопкой.

Потестил у себя на InDesign CC2020 очень бегло, вы сможете тщательнее потестировать на своих примерах. Расскажите как будет себя вести.